### PR TITLE
Removed PyBonjour Dependency. Instead using Avahi

### DIFF
--- a/LinConnectServer/install.sh
+++ b/LinConnectServer/install.sh
@@ -20,29 +20,27 @@ then
 	echo "* python-gobject"
 	echo "* libavahi-compat-libdnssd1"
 	echo "* cherrypy (python package)"
-	echo "* pybonjour (python package)"
 	
     else
 	echo "Installing dependencies..."
 	sudo yum install -y python2 python-pip pygobject2 git avahi-compat-libdns_sd
 	echo "Installing Python dependencies..."
-	sudo pip install cherrypy pybonjour
+	sudo pip install cherrypy
     fi
 else
 	echo "Installing dependencies..."
 	sudo apt-get install -y python-pip python-gobject git libavahi-compat-libdnssd1 gir1.2-notify-0.7
 	echo "Installing Python dependencies..."
-	sudo pip install --allow-external pybonjour --allow-unverified pybonjour pybonjour
 	sudo pip install cherrypy
 fi
 
 read -p "Press any key to continue..." -n 1 -r
 
 echo "Installing LinConnect..."
-git clone -q https://github.com/hauckwill/linconnect-server.git ~/.linconnect
+git clone -q https://github.com/PrasannaVenkadesh/linconnect-server.git ~/.linconnect
 cd ~/.linconnect
 echo "Setting up LinConnect..."
-git remote add upstream https://github.com/hauckwill/linconnect-server.git
+git remote add upstream https://github.com/PrasannaVenkadesh/linconnect-server.git
 
 read -p "Autostart LinConnect server on boot? [Y/N]" -n 1 -r
 echo    # (optional) move to a new line

--- a/LinConnectServer/main/ZeroconfService.py
+++ b/LinConnectServer/main/ZeroconfService.py
@@ -1,0 +1,55 @@
+import dbus
+import sys
+
+__all__ = ["ZeroconfService"]
+sys.dont_write_bytecode = True
+
+
+class ZeroconfService:
+    """
+    A very simple class to publish a network service with Zeroconf using avahi.
+    """
+
+    def __init__(self, name, port, stype="_linconnect._tcp", domain="", host="", text=""):
+        self.name = name
+        self.port = port
+        self.stype = stype
+        self.domain = domain
+        self.host = host
+        self.text = text
+
+        # AVAHI Configuration Variables
+        self.DBUS_NAME = "org.freedesktop.Avahi"
+        self.DBUS_PATH_SERVER = "/"
+        self.DBUS_INTERFACE_SERVER = self.DBUS_NAME + ".Server"
+        self.DBUS_INTERFACE_ENTRY_GROUP = self.DBUS_NAME + ".EntryGroup"
+        self.IF_UNSPEC = -1
+        self.PROTO_UNSPEC = -1
+
+
+    def publish(self):
+        bus = dbus.SystemBus()
+        server = dbus.Interface(bus.get_object(self.DBUS_NAME,
+                                               self.DBUS_PATH_SERVER),
+                                               self.DBUS_INTERFACE_SERVER)
+
+        g = dbus.Interface(bus.get_object(self.DBUS_NAME,
+                                          server.EntryGroupNew()),
+                           self.DBUS_INTERFACE_ENTRY_GROUP)
+
+        g.AddService(self.IF_UNSPEC, self.PROTO_UNSPEC, dbus.UInt32(0),
+                     self.name, self.stype, self.domain, self.host,
+                     dbus.UInt16(self.port), self.text)
+
+        g.Commit()
+        self.group = g
+
+    def unpublish(self):
+        self.group.Reset()
+
+
+def test():
+    service = ZeroconfService(name="TestService", port=3000)
+    service.publish()
+    raw_input("Press anykey to unpublish the service ")
+    service.unpublish()

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Installation
 * python-gobject
 * libavahi-compat-libdnssd1
 * cherrypy (python package)
-* pybonjour (python package)
 
 **Running**
 


### PR DESCRIPTION
I saw lot of issues and bug reports saying, the install.sh script failed while trying to install pybonjour package even with allow-external option enabled. Infact, I do faced it on debian.

So removed PyBonjour dependency, instead replaced with freedesktop's avahi.